### PR TITLE
Remove validation for enum fields in PHP library

### DIFF
--- a/src/main/resources/handlebars/php/model_generic.mustache
+++ b/src/main/resources/handlebars/php/model_generic.mustache
@@ -350,29 +350,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      */
     public function {{setter}}(${{name}})
     {
-        {{#is this 'enum'}}
-        $allowedValues = $this->{{getter}}AllowableValues();
-        {{#isNot this 'container'}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}!in_array(${{{name}}}, $allowedValues)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value for '{{name}}', must be one of '%s'",
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
-        {{/isNot}}
-        {{#is this 'container'}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}array_diff(${{{name}}}, $allowedValues)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value for '{{name}}', must be one of '%s'",
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
-        {{/is}}
-        {{/is}}
         {{#has this 'validation'}}
         {{#maxLength}}
         if ({{^required}}!is_null(${{name}}) && {{/required}}(strlen(${{name}}) > {{maxLength}})) {


### PR DESCRIPTION
When a new enum value is added to the server, old versions of the PHP library will not allow this new value and trigger an exception. By removing the validation for the allowed enum values, the server can be updated with a new value without breaking the old library versions.